### PR TITLE
This change set fixes two issues in the credentials.yml.example file.

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -1,11 +1,14 @@
 :client_id: your-oauth-client-id
 :client_secret: your-oauth-client-secret
-:access_token: See Readme.md
+:refresh_token: See Readme.md
 :doc: some-doc-id
 
 # If you have a nice short url
 # :short: https://tinyurl.com/foo-pair
 
 # For email sending
+#
+# Note: You can go to https://myaccount.google.com/apppasswords to generate an
+#       application password if your account uses 2-Step Verification
 :username: "foo@gmail.com"
 :password: "foo-password"


### PR DESCRIPTION
1) It changes the `access_token` key to `refresh_token`, which is the proper value expected at runtime.

2) It adds a note to set up an application password when the Google Account is using 2-Step verification.